### PR TITLE
Fix default-branch pipeline deprecation failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "contributte/qa": "^0.4.0",
     "contributte/phpstan": "^0.1.0",
-    "contributte/tester": "^0.2.0"
+    "contributte/tester": "^0.4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary
- update `contributte/tester` from `^0.2.0` to `^0.4.0` to use a PHP 8.4/8.5-compatible test environment helper
- this removes the deprecated `lcg_value()` call path that currently breaks default-branch `Nette Tester` and `Coverage` workflows
- no linked issue found in `contributte/dev` for this pipeline failure

## Verification
- `make tests`
- `make qa`