### PR TITLE
Makefile: use php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Switch the `coverage` target in `Makefile` from `phpdbg` to `php` as part of the org-wide coverage migration.

## Motivation

`phpdbg` is being removed from Contributte coverage targets in contributte/contributte#73 so repositories use the standard PHP binary consistently.

## Changes

- replace `-p phpdbg` with `-p php` in the CI coverage command
- replace `-p phpdbg` with `-p php` in the local coverage command

## Testing

- [x] Tests pass locally (`make tests`)
- [ ] Coverage passes locally (`make coverage` fails because this environment does not have Xdebug or PCOV enabled for `php`)
- [ ] CI passes